### PR TITLE
Verify that METADATA is not empty before looping

### DIFF
--- a/src/Parsers/GetMetadata/Object.php
+++ b/src/Parsers/GetMetadata/Object.php
@@ -12,7 +12,7 @@ class Object extends Base
 
         $collection = new Collection;
 
-        if ($xml->METADATA) {
+        if ($xml->METADATA and !empty($xml->METADATA) {
             foreach ($xml->METADATA->{'METADATA-OBJECT'}->Object as $key => $value) {
                 $metadata = new \PHRETS\Models\Metadata\Object;
                 $metadata->setSession($rets);


### PR DESCRIPTION
over nonexistent objects